### PR TITLE
Rework the scripts to support Amazon Linux 2 LTS Candidate AMI 2017.12.0

### DIFF
--- a/kibana.tf
+++ b/kibana.tf
@@ -7,7 +7,7 @@ data "template_file" "kibana" {
         vpc_cidr   = "${var.vpc_cidr}"
         hostname   = "${element(keys(var.kibana_ip_addresses),0)}"
         domainname = "${var.dns_zone}"
-        es_version = "${lookup(var.versions, "kibana")}"
+        es_version = "${lookup(var.versions, "elasticsearch")}"
         es_url     = "http://${aws_elb.elasticsearch.dns_name}:9200"
     }
 }

--- a/resources/minion/bootstrap-minion.sh
+++ b/resources/minion/bootstrap-minion.sh
@@ -156,6 +156,12 @@ class-name=org.opennms.netmgt.telemetry.listeners.udp.UdpListener
 listener.port=50001
 EOF
 
+  cat <<EOF > org.opennms.features.telemetry.listeners-udp-8877.cfg
+name=Netflow-5
+class-name=org.opennms.netmgt.telemetry.listeners.udp.UdpListener
+listener.port=8877
+EOF
+
   systemctl enable minion
   systemctl start minion
 fi

--- a/templates/activemq.tpl
+++ b/templates/activemq.tpl
@@ -25,7 +25,7 @@ sed -i -r "s|ZONE=.*|ZONE=$timezone|" /etc/sysconfig/clock
 echo "### Installing common packages..."
 
 yum -y -q update
-yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat
+yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat nmap-ncat
 
 echo "### Configuring and enabling SNMP..."
 

--- a/templates/activemq.tpl
+++ b/templates/activemq.tpl
@@ -44,8 +44,8 @@ disk /
 EOF
 
 chmod 600 $snmp_cfg
-chkconfig snmpd on
-service snmpd start snmpd
+systemctl enable snmpd
+systemctl start snmpd
 
 echo "### Downloading and installing Oracle JDK..."
 
@@ -158,5 +158,5 @@ EOF
 
 echo "### Enabling and starting ActiveMQ..."
 
-chkconfig activemq on
-service activemq start
+systemctl enable activemq
+systemctl start activemq

--- a/templates/cassandra.tpl
+++ b/templates/cassandra.tpl
@@ -26,7 +26,7 @@ sed -i -r "s|ZONE=.*|ZONE=$timezone|" /etc/sysconfig/clock
 echo "### Installing common packages..."
 
 yum -y -q update
-yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat
+yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat nmap-ncat
 
 echo "### Configuring and enabling SNMP..."
 

--- a/templates/cassandra.tpl
+++ b/templates/cassandra.tpl
@@ -119,7 +119,7 @@ echo "### Checking cluster prior start..."
 
 start_delay=$((60*(${node_id}-1)))
 if [[ $start_delay != 0 ]]; then
-  until nc -z ${seed_name} 9042; do
+  until echo -n > /dev/tcp/${seed_name}/9042; do
     echo "### ${seed_name} is unavailable - sleeping"
     sleep 5
   done

--- a/templates/cassandra.tpl
+++ b/templates/cassandra.tpl
@@ -45,8 +45,8 @@ disk /
 EOF
 
 chmod 600 $snmp_cfg
-chkconfig snmpd on
-service snmpd start snmpd
+systemctl enable snmpd
+systemctl start snmpd
 
 echo "### Downloading and installing Oracle JDK..."
 
@@ -129,5 +129,5 @@ fi
 
 echo "### Enabling and starting Cassandra..."
 
-chkconfig cassandra on
-service cassandra start
+systemctl enable cassandra
+systemctl start cassandra

--- a/templates/elasticsearch.tpl
+++ b/templates/elasticsearch.tpl
@@ -81,7 +81,7 @@ echo "### Checking cluster prior start..."
 
 start_delay=$((60*(${node_id}-1)))
 if [[ $start_delay != 0 ]]; then
-  until nc -z ${es_seed_name} 9200; do
+  until echo -n > /dev/tcp/${es_seed_name}/9200; do
     echo "### ${es_seed_name} is unavailable - sleeping"
     sleep 5
   done

--- a/templates/elasticsearch.tpl
+++ b/templates/elasticsearch.tpl
@@ -43,8 +43,8 @@ disk /
 EOF
 
 chmod 600 $snmp_cfg
-chkconfig snmpd on
-service snmpd start snmpd
+systemctl enable snmpd
+systemctl start snmpd
 
 echo "### Downloading and installing Oracle JDK..."
 
@@ -95,5 +95,5 @@ start_delay=$((60*(${node_id}-1)))
 echo "### Waiting $start_delay seconds prior starting Elasticsearch..."
 sleep $start_delay
 
-chkconfig elasticsearch on
-service elasticsearch start
+systemctl enable elasticsearch
+systemctl start elasticsearch

--- a/templates/elasticsearch.tpl
+++ b/templates/elasticsearch.tpl
@@ -24,7 +24,7 @@ sed -i -r "s|ZONE=.*|ZONE=$timezone|" /etc/sysconfig/clock
 echo "### Installing common packages..."
 
 yum -y -q update
-yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat
+yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat nmap-ncat
 
 echo "### Configuring and enabling SNMP..."
 

--- a/templates/kafka.tpl
+++ b/templates/kafka.tpl
@@ -29,7 +29,7 @@ sed -i -r "s|ZONE=.*|ZONE=$timezone|" /etc/sysconfig/clock
 echo "### Installing common packages..."
 
 yum -y -q update
-yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat
+yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat nmap-ncat
 
 echo "### Configuring and enabling SNMP..."
 
@@ -127,7 +127,7 @@ After=network.target remote-fs.target zookeeper.service
 Type=forking
 User=root
 Group=root
-Environment="KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=%H -Djava.net.preferIPv4Stack=true"
+Environment="KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=%H -Djava.net.preferIPv4Stack=true"
 Environment="JMX_PORT=9999"
 # Uncomment the following line to enable authentication for the broker
 # Environment="KAFKA_OPTS=-Djava.security.auth.login.config=/etc/kafka/kafka-jaas.conf"

--- a/templates/kafka.tpl
+++ b/templates/kafka.tpl
@@ -48,8 +48,8 @@ disk /
 EOF
 
 chmod 600 $snmp_cfg
-chkconfig snmpd on
-service snmpd start snmpd
+systemctl enable snmpd
+systemctl start snmpd
 
 echo "### Downloading and installing Oracle JDK..."
 
@@ -113,66 +113,31 @@ kafka kafka
 EOF
 chmod 400 $password_file
 
-kafka_init_d=/etc/init.d/kafka
-cat <<EOF > $kafka_init_d
-#!/bin/bash
-#
-# chkconfig: 345 99 01
-# description: Kafka Server
-#
-### BEGIN INIT INFO
-# Provides: kafka
-# Required-Start: $local_fs $network
-# Required-Stop: $local_fs $network
-# Default-Start: 3 5
-# Default-Stop: 0 1 2 6
-# Description: Kafka Server
-# Short-Description: Kafka Server
-### END INIT INFO
+systemd_kafka=/etc/systemd/system/kafka.service
+cat <<EOF > $systemd_kafka
+# Inspired by https://github.com/thmshmm/confluent-systemd
 
-PROG=kafka
-DAEMON_PATH=/opt/kafka/bin
-PATH=\$PATH:\$DAEMON_PATH
+[Unit]
+Description=Apache Kafka server (broker)
+Documentation=http://kafka.apache.org/documentation.html
+Requires=network.target remote-fs.target
+After=network.target remote-fs.target zookeeper.service
 
-HOSTNAME=\`hostname\`
-export JMX_PORT=9999
-export KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.rmi.port=\$JMX_PORT -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=\$HOSTNAME -Djava.net.preferIPv4Stack=true"
+[Service]
+Type=forking
+User=root
+Group=root
+Environment="KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=%H -Djava.net.preferIPv4Stack=true"
+Environment="JMX_PORT=9999"
+# Uncomment the following line to enable authentication for the broker
+# Environment="KAFKA_OPTS=-Djava.security.auth.login.config=/etc/kafka/kafka-jaas.conf"
+ExecStart=/opt/kafka/bin/kafka-server-start.sh -daemon /opt/kafka/config/server.properties
+ExecStop=/opt/kafka/bin/kafka-server-stop.sh
 
-pid=\`ps ax | grep -i 'kafka.Kafka' | grep -v grep | awk '{print \$1}'\`
-
-case "\$1" in
-  start)
-    if [ -n "\$pid" ]; then
-      echo "\$PROG is already running"
-    else
-      echo -n "Starting \$PROG: ";echo
-      \$DAEMON_PATH/kafka-server-start.sh -daemon /opt/kafka/config/server.properties
-    fi
-    ;;
-  stop)
-    echo -n "Stopping \$PROG: ";echo
-    \$DAEMON_PATH/kafka-server-stop.sh
-    ;;
-  restart)
-    \$0 stop
-    sleep 5
-    \$0 start
-    ;;
-  status)
-    if [ -n "\$pid" ]; then
-      echo "\$PROG is Running as PID: \$pid"
-    else
-      echo "\$PROG is not Running"
-    fi
-    ;;
-  *)
-    echo "Usage: \$0 {start|stop|restart|status}"
-    exit 1
-esac
-
-exit 0
+[Install]
+WantedBy=multi-user.target
 EOF
-chmod +x $kafka_init_d
+chmod 0644 $systemd_kafka
 
 echo "### Configuring Kernel..."
 
@@ -188,5 +153,6 @@ start_delay=$((60*(${node_id})))
 echo "### Waiting $start_delay seconds prior starting Kafka..."
 sleep $start_delay
 
-chkconfig kafka on
-service kafka start
+systemctl daemon-reload
+systemctl enable kafka
+systemctl start kafka

--- a/templates/kibana.tpl
+++ b/templates/kibana.tpl
@@ -24,7 +24,7 @@ sed -i -r "s|ZONE=.*|ZONE=$timezone|" /etc/sysconfig/clock
 echo "### Installing common packages..."
 
 yum -y -q update
-yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat
+yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat nmap-ncat
 
 echo "### Configuring and enabling SNMP..."
 

--- a/templates/kibana.tpl
+++ b/templates/kibana.tpl
@@ -43,8 +43,8 @@ disk /
 EOF
 
 chmod 600 $snmp_cfg
-chkconfig snmpd on
-service snmpd start snmpd
+systemctl enable snmpd
+systemctl start snmpd
 
 echo "### Installing Elasticsearch and Kibana..."
 
@@ -61,5 +61,5 @@ sed -i -r "s|[#]elasticsearch.url:.*|elasticsearch.url: ${es_url}|" $kb_yaml
 
 echo "### Enabling and starting Kibana..."
 
-chkconfig kibana on
-service kibana start
+systemctl enable kibana
+systemctl start kibana

--- a/templates/opennms.core.tpl
+++ b/templates/opennms.core.tpl
@@ -31,7 +31,7 @@ sed -i -r "s|ZONE=.*|ZONE=$timezone|" /etc/sysconfig/clock
 echo "### Installing common packages..."
 
 yum -y -q update
-yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat
+yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat nmap-ncat
 
 echo "### Configuring and enabling SNMP..."
 
@@ -127,7 +127,7 @@ cat <<EOF > $opennms_etc/opennms-datasources.xml
   <jdbc-data-source name="opennms"
                     database-name="opennms"
                     class-name="org.postgresql.Driver"
-                    url="jdbc:postgresql://${postgres_server}/opennms"
+                    url="jdbc:postgresql://${postgres_server}:5432/opennms"
                     user-name="opennms"
                     password="opennms">
     <param name="connectionTimeout" value="0"/>
@@ -136,7 +136,7 @@ cat <<EOF > $opennms_etc/opennms-datasources.xml
   <jdbc-data-source name="opennms-admin"
                     database-name="template1"
                     class-name="org.postgresql.Driver"
-                    url="jdbc:postgresql://${postgres_server}/template1"
+                    url="jdbc:postgresql://${postgres_server}:5432/template1"
                     user-name="postgres"
                     password="postgres" />
 </datasource-configuration>
@@ -259,11 +259,12 @@ for f in "$${files[@]}"; do
   fi
 done
 
-# Fix Karaf logging: NMS-9773
-sed -r -i '/log4j2.logger.opennms.additivity = false/d' $opennms_etc/org.ops4j.pax.logging.cfg
-
-# Disabling datachoices
-sed -r -i '/datachoices/d' $opennms_etc/org.apache.karaf.features.cfg
+# TODO: the following is due to some issues with the datachoices plugin
+cat <<EOF > $opennms_etc/org.opennms.features.datachoices.cfg
+enabled=false
+acknowledged-by=admin
+acknowledged-at=Mon Jan 01 00\:00\:00 EDT 2018
+EOF
 
 echo "### Configuring OpenNMS Jetty Server..."
 

--- a/templates/opennms.ui.tpl
+++ b/templates/opennms.ui.tpl
@@ -32,7 +32,7 @@ sed -i -r "s|ZONE=.*|ZONE=$timezone|" /etc/sysconfig/clock
 echo "### Installing common packages..."
 
 yum -y -q update
-yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat
+yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat nmap-ncat
 
 echo "### Configuring and enabling SNMP..."
 

--- a/templates/opennms.ui.tpl
+++ b/templates/opennms.ui.tpl
@@ -51,8 +51,8 @@ disk /
 EOF
 
 chmod 600 $snmp_cfg
-chkconfig snmpd on
-service snmpd start snmpd
+systemctl enable snmpd
+systemctl start snmpd
 
 echo "### Creating and configuring external mount point for OpenNMS configuration..."
 
@@ -69,14 +69,15 @@ echo "### Installing PostgreSQL tools..."
 pg_version=`echo ${pg_repo_version} | sed 's/-.//'`
 pg_family=`echo $pg_version | sed 's/\.//'`
 
-yum install -y -q https://download.postgresql.org/pub/repos/yum/$pg_version/redhat/rhel-6-x86_64/pgdg-ami201503-$pg_family-${pg_repo_version}.noarch.rpm
+yum install -y -q https://download.postgresql.org/pub/repos/yum/$pg_version/redhat/rhel-7-x86_64/pgdg-centos$pg_family-${pg_repo_version}.noarch.rpm
+sed -i -r 's/[$]releasever/7/g' /etc/yum.repos.d/pgdg-$pg_family-centos.repo
 yum install -y -q postgresql$pg_family
 
 echo "### Installing OpenNMS Dependencies from stable repository..."
 
-sed -r -i '/name=amzn-main-Base/a exclude=rrdtool-*' /etc/yum.repos.d/amzn-main.repo
-yum install -y -q http://yum.opennms.org/repofiles/opennms-repo-stable-rhel6.noarch.rpm
-rpm --import /etc/yum.repos.d/opennms-repo-stable-rhel6.gpg
+sed -r -i '/name=Amazon Linux 2/a exclude=rrdtool-*' /etc/yum.repos.d/amzn2-core.repo
+yum install -y -q http://yum.opennms.org/repofiles/opennms-repo-stable-rhel7.noarch.rpm
+rpm --import /etc/yum.repos.d/opennms-repo-stable-rhel7.gpg
 yum install -y -q jicmp jicmp6 jrrd jrrd2 rrdtool 'perl(LWP)' 'perl(XML::Twig)'
 
 echo "### Downloading and installing Oracle JDK..."
@@ -86,7 +87,6 @@ java_rpm=/tmp/jdk8-linux-x64.rpm
 wget -c --quiet --header "Cookie: oraclelicense=accept-securebackup-cookie" -O $java_rpm $java_url
 if [ ! -s $java_rpm ]; then
   echo "FATAL: Cannot download Java from $java_url. Using OpenNMS default ..."
-  yum install -y -q jdk1.8.0_144
 else
   yum install -y -q $java_rpm
   rm -f $java_rpm
@@ -95,8 +95,8 @@ fi
 if [ "${onms_repo}" != "stable" ]; then
   echo "### Installing OpenNMS ${onms_repo} Repository..."
   yum remove -y -q opennms-repo-stable
-  yum install -y -q http://yum.opennms.org/repofiles/opennms-repo-${onms_repo}-rhel6.noarch.rpm
-  rpm --import /etc/yum.repos.d/opennms-repo-${onms_repo}-rhel6.gpg
+  yum install -y -q http://yum.opennms.org/repofiles/opennms-repo-${onms_repo}-rhel7.noarch.rpm
+  rpm --import /etc/yum.repos.d/opennms-repo-${onms_repo}-rhel7.gpg
 fi
 
 if [ "${onms_version}" == "-latest-" ]; then
@@ -317,8 +317,9 @@ touch $opennms_etc/configured
 
 echo "### Enabling and starting OpenNMS Core..."
 
-chkconfig opennms on
-service opennms start
+systemctl daemon-reload
+systemctl enable opennms
+systemctl start opennms
 
 echo "### Configurng Grafana..."
 
@@ -347,6 +348,5 @@ rm -f ~/.pgpass
 
 echo "### Starting and enabling Grafana server..."
 
-service grafana-server start
-chkconfig grafana-server on
-
+systemctl enable grafana-server
+systemctl start grafana-server

--- a/templates/postgresql.tpl
+++ b/templates/postgresql.tpl
@@ -23,7 +23,7 @@ sed -i -r "s|ZONE=.*|ZONE=$timezone|" /etc/sysconfig/clock
 echo "### Installing common packages..."
 
 yum -y -q update
-yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat
+yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat nmap-ncat
 
 echo "### Configuring and enabling SNMP..."
 

--- a/templates/zookeeper.tpl
+++ b/templates/zookeeper.tpl
@@ -44,8 +44,8 @@ disk /
 EOF
 
 chmod 600 $snmp_cfg
-chkconfig snmpd on
-service snmpd start snmpd
+systemctl enable snmpd
+systemctl start snmpd
 
 echo "### Downloading and installing Oracle JDK..."
 
@@ -78,64 +78,25 @@ rm -f $zk_file
 
 echo "### Configuring Zookeeper..."
 
-zoo_init_d=/etc/init.d/zookeeper
-cat <<EOF > $zoo_init_d
-#!/bin/sh
-#
-# chkconfig: 345 99 01
-# description: Zookeeper Server
-#
-### BEGIN INIT INFO
-# Provides: zookeeper
-# Required-Start: $local_fs $network
-# Required-Stop: $local_fs $network
-# Default-Start: 3 5
-# Default-Stop: 0 1 2 6
-# Description: Zookeeper Server
-# Short-Description: Zookeeper Server
-### END INIT INFO
+systemd_zoo=/etc/systemd/system/zookeeper.service
+cat <<EOF > $systemd_zoo
+[Unit]
+Description=Apache Zookeeper server (Kafka)
+Documentation=http://zookeeper.apache.org
+Requires=network.target remote-fs.target
+After=network.target remote-fs.target
 
-USER=root
-PROG=zookeeper
-DAEMON_PATH=/opt/zookeeper/bin
-DAEMON_NAME=zkServer.sh
-PATH=\$PATH:\$DAEMON_PATH
+[Service]
+Type=forking
+User=root
+Group=root
+ExecStart=/opt/zookeeper/bin/zkServer.sh start
+ExecStop=/opt/zookeeper/bin/zkServer.sh stop
 
-pid=\`ps ax | grep -i 'zookeeper.server' | grep -v grep | awk '{print \$1}'\`
-
-case "\$1" in
-  start)
-    if [ -n "\$pid" ]; then
-      echo "\$PROG is already running"
-    else
-      echo -n "Starting \$PROG: ";echo
-      /bin/su \$USER \$DAEMON_PATH/\$DAEMON_NAME start
-    fi
-    ;;
-  stop)
-    echo -n "Stopping \$PROG: ";echo
-    /bin/su \$USER \$DAEMON_PATH/\$DAEMON_NAME stop
-    ;;
-  status)
-    if [ -n "\$pid" ]; then
-      echo "\$PROG is Running as PID: \$pid"
-    else
-      echo "\$PROG is not Running"
-    fi
-    /bin/su \$USER \$DAEMON_PATH/\$DAEMON_NAME status
-    ;;
-  restart)
-    \$0 stop
-    sleep 5
-    \$0 start
-    ;;
-  *)
-    echo "Usage: \$0 {start|stop|status|restart}"
-    exit 1
-esac
-exit 0
+[Install]
+WantedBy=multi-user.target
 EOF
-chmod +x $zoo_init_d
+chmod 0644 $systemd_zoo
 
 zoo_data=/data/zookeeper
 mkdir -p $zoo_data
@@ -180,5 +141,6 @@ start_delay=$((60*(${node_id}-1)))
 echo "### Waiting $start_delay seconds prior starting Zookeeper..."
 sleep $start_delay
 
-chkconfig zookeeper on
-service zookeeper start
+systemctl daemon-reload
+systemctl enable zookeeper
+systemctl start zookeeper

--- a/templates/zookeeper.tpl
+++ b/templates/zookeeper.tpl
@@ -25,7 +25,7 @@ sed -i -r "s|ZONE=.*|ZONE=$timezone|" /etc/sysconfig/clock
 echo "### Installing common packages..."
 
 yum -y -q update
-yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat
+yum -y -q install jq net-snmp net-snmp-utils git pytz dstat htop sysstat nmap-ncat
 
 echo "### Configuring and enabling SNMP..."
 

--- a/vars.tf
+++ b/vars.tf
@@ -19,15 +19,15 @@ variable "aws_region" {
     default = "us-east-2" # For testing purposes only
 }
 
-variable "aws_amis" {  # Amazon Linux
+variable "aws_amis" {  # Amazon Linux 2 LT SCandidate AMI 2017.12.0
     description = "AMIs by region"
     type = "map"
 
     default = {
-        us-east-1 = "ami-4fffc834"
-        us-east-2 = "ami-ea87a78f"
-        us-west-1 = "ami-3a674d5a"
-        us-west-2 = "ami-aa5ebdd2"
+        us-east-1 = "ami-428aa838"
+        us-east-2 = "ami-710e2414"
+        us-west-1 = "ami-4a787a2a"
+        us-west-2 = "ami-7f43f307"
     }
 }
 
@@ -181,7 +181,7 @@ variable "versions" {
         kafka           = "1.0.0"
         scala           = "2.12"
         zookeeper       = "3.4.11"
-        postgresql_repo = "9.6-2"
+        postgresql_repo = "9.6-3"
         cassandra_repo  = "311x"
         onms_repo       = "branches-features-drift"
         onms_version    = "-latest-"

--- a/vars.tf
+++ b/vars.tf
@@ -175,8 +175,7 @@ variable "versions" {
     type = "map"
 
     default = {
-        elasticsearch   = "6.1.1"
-        kibana          = "6.1.1"
+        elasticsearch   = "6.2.1"
         activemq        = "5.13.5"
         kafka           = "1.0.0"
         scala           = "2.12"


### PR DESCRIPTION
The new Amazon Linux 2, supports systemd, and it seems to be compatible with RHEL/CentOS 7 repositories. So, the main difference, besides having systemd initialization files instead of plain-old `init.d` scripts, is using a different way to check if the apps are running, as `nc -vz` doesn't exist on this AMI (or RHEL/CentOS  7).

The solution has been verified using latest RPMs from `features/drift`